### PR TITLE
only support high contrast for bootstrap theme

### DIFF
--- a/GUIDELINES.md
+++ b/GUIDELINES.md
@@ -22,7 +22,8 @@ if the committer feels this is not hurting the code readability.
 * All widget/custom elements MUST be enabled for globalization (including translatability & bidi support)
 * All widget/custom elements MUST be enabled for accessibility:
     * keyboard support
-    * high contrast support (IE and FF on Windows, with High Contrast mode enabled in the os settings)
+    * high contrast support (IE and FF on Windows, with High Contrast mode enabled in the os settings);
+      only necessary for bootstrap theme
     * zoom (full zoom, not text only zoom, up to 200%)
     * screen reader accessibility (supported readers are JAWS on Windows and VoiceOver on iOS)
 * Variables SHOULD be declared as close to the point where they are first used as it helps to cluster groups of code


### PR DESCRIPTION
Presumably we only require supporting high-contrast mode on bootstrap theme.

For bootstrap we'll use font-icons, which show up fine even in high contrast mode, but for iOS/android themes we may want to use actual images, to get multiple colors etc.

So, we should only require supporting high-contrast mode for bootstrap theme.
